### PR TITLE
Lower version requirement to PHP 8.1.

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '8.4' ]
+                php: [ '8.1', '8.2', '8.3', '8.4' ]
                 composer-flags: [ '' ]
                 phpunit-flags: [ '--coverage-text' ]
         steps:
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '8.4' ]
+                php: [ '8.1', '8.2', '8.3', '8.4' ]
                 composer-flags: [ '' ]
         steps:
             - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~8.4",
+        "php": "~8.1",
         "psr/http-message": "^2.0",
         "psr/http-factory": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/http-factory": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.1.0",
+        "phpunit/phpunit": "^10.5.46",
         "phpbench/phpbench": "^1.4.1",
         "phpstan/phpstan": "^2.1.11",
         "nyholm/psr7": "^1.8"

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -9,11 +9,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
-readonly class ResponseBuilder
+class ResponseBuilder
 {
     public function __construct(
-        private ResponseFactoryInterface $responseFactory,
-        private StreamFactoryInterface $streamFactory,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
     ) {
     }
 

--- a/tests/ResponseBuilderTest.php
+++ b/tests/ResponseBuilderTest.php
@@ -39,7 +39,7 @@ class ResponseBuilderTest extends TestCase
     #[Test]
     public function arbitrary_with_stream_body(): void
     {
-        $stream = new Psr17Factory()->createStream('Hello World');
+        $stream = (new Psr17Factory())->createStream('Hello World');
         $response = $this->builder()->createResponse(HttpStatus::OK, $stream);
 
         self::assertEquals('Hello World', $response->getBody()->getContents());


### PR DESCRIPTION
We're not actually using any 8.4 features at this point that are really necessary.